### PR TITLE
Provide example of input for contributors section

### DIFF
--- a/draft-ietf-core-coap-pm.md
+++ b/draft-ietf-core-coap-pm.md
@@ -79,6 +79,11 @@ author:
   country: Italy
   email: fabrizio.milan@telecomitalia.it
 
+contributor:
+- name: Joe Bloggs
+  org: Bloggsers are us
+  email: joe@bloggs.us
+
 normative:
   RFC7252:
   RFC8613:


### PR DESCRIPTION
I added an example for an entry in the contributors section.
These look like entries in the authors section, but don't count towards the RFC editor's limit of 5 authors for an RFC.
This is just a suggestion, use as you see fit.